### PR TITLE
ui: v2 polish — dark palette, always-visible actions, consolidated git sync

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -203,9 +203,13 @@ The **Connect** action (green Play icon) is the primary CTA on every
 connection row and tile and is **always visible** — it does not wait
 for hover, so the action is reachable for keyboard and touch users and
 discoverable on the very first visit. Secondary actions (Transfer
-files, Clone, Edit, Delete) remain in a hover-revealed group to keep
-the list visually quiet, and that group also expands when any of its
-buttons receives keyboard focus (`focus-within`).
+files, Clone, Edit, Delete) are likewise rendered in their resting
+state at all times: the v2 redesign deliberately removed the
+hover-reveal pattern so users know up-front exactly what is available
+on each row without any discovery cost. Port-forward connections
+render the Transfer-files (SCP) icon in a disabled state with an
+explanatory `title` tooltip rather than hiding it, so the affordance
+remains predictable across connection kinds.
 
 ### List Keyboard Navigation
 

--- a/docs/git-sync.md
+++ b/docs/git-sync.md
@@ -23,10 +23,13 @@ The Git Sync view supports:
 
 - Export sanitized snapshot
 - Refresh diff
-- Fetch
-- Pull (requires confirmation — fast-forward / merge can overwrite local uncommitted snapshot changes)
-- Commit
-- Push (requires confirmation — mutates the shared remote)
+- Commit (with editable commit message)
+- One-click bidirectional **Sync** (see below)
+
+The previously separate Fetch / Pull / Push toolbar buttons were collapsed
+into the single `Sync` action — the underlying store still exposes the
+individual primitives for tests and future automation, but the UI no
+longer surfaces them as standalone destructive operations.
 
 ## One-Click Sync
 

--- a/e2e/helpers/flows.ts
+++ b/e2e/helpers/flows.ts
@@ -22,6 +22,28 @@ async function click(selector: string): Promise<void> {
   await el.click();
 }
 
+async function clickDialogFooterButton(selector: string): Promise<void> {
+  const el = await browser.$(selector);
+  await el.waitForExist({ timeout: 10_000 });
+
+  // Linux tauri-driver/WebKit sometimes fails to scroll sticky dialog
+  // footer buttons into the viewport via WebDriver Actions, producing
+  // "move target out of bounds" and then a false non-clickable timeout.
+  // Force the same scroll from inside the page, then fall back to a DOM
+  // click only if the driver still refuses to perform a native click.
+  await browser.execute(
+    (button: HTMLElement) => button.scrollIntoView({ block: "center" }),
+    el,
+  );
+
+  try {
+    await el.waitForClickable({ timeout: 5_000 });
+    await el.click();
+  } catch {
+    await browser.execute((button: HTMLElement) => button.click(), el);
+  }
+}
+
 export async function navigateTo(view: "connections" | "credentials" | "tunnels" | "settings" | "git-sync" | "logs"): Promise<void> {
   const map = {
     connections: sel.navConnections,
@@ -60,6 +82,12 @@ export interface DirectConnectionInput {
   credentialName: string;
 }
 
+export async function saveConnectionForm(): Promise<void> {
+  await clickDialogFooterButton(sel.connectionFormSubmit);
+  const form = await browser.$(sel.connectionForm);
+  await form.waitForExist({ reverse: true, timeout: 10_000 });
+}
+
 export async function createDirectConnection(input: DirectConnectionInput): Promise<void> {
   await navigateTo("connections");
   await click(sel.addConnectionButton);
@@ -75,9 +103,7 @@ export async function createDirectConnection(input: DirectConnectionInput): Prom
   const opt = await browser.$(`[role="option"][data-name="${input.credentialName}"]`);
   await opt.waitForClickable({ timeout: 10_000 });
   await opt.click();
-  await click(sel.connectionFormSubmit);
-  const form = await browser.$(sel.connectionForm);
-  await form.waitForExist({ reverse: true, timeout: 10_000 });
+  await saveConnectionForm();
 }
 
 /**

--- a/e2e/specs/09-tag-groups.spec.ts
+++ b/e2e/specs/09-tag-groups.spec.ts
@@ -26,6 +26,7 @@ import { TARGETS, waitForServers } from "../helpers/docker.js";
 import {
   createPasswordCredential,
   createDirectConnection,
+  saveConnectionForm,
   navigateTo,
 } from "../helpers/flows.js";
 import { sel } from "../helpers/selectors.js";
@@ -57,26 +58,7 @@ async function tagConnection(name: string, tag: string): Promise<void> {
   // wdio because comma can be remapped on some keyboard layouts.
   await tagsInput.setValue(tag);
   await browser.keys(["Enter"]);
-    const submit = await browser.$(sel.connectionFormSubmit);
-    await submit.waitForExist({ timeout: 10_000 });
-    // The connection form is a tall scrollable dialog; on Linux CI the
-    // WebDriver Actions API occasionally reports "move target out of
-    // bounds" when trying to scroll the sticky DialogFooter button into
-    // view, leaving `waitForClickable` to time out. Force-scroll via JS
-    // first (matches what wdio's auto-scroll attempts but reliably) and
-    // fall back to a JS click if Actions still refuses to fire.
-    await browser.execute(
-      (el: HTMLElement) => el.scrollIntoView({ block: "center" }),
-      submit,
-    );
-    try {
-      await submit.waitForClickable({ timeout: 5_000 });
-      await submit.click();
-    } catch {
-      await browser.execute((el: HTMLElement) => el.click(), submit);
-    }
-    const form = await browser.$(sel.connectionForm);
-    await form.waitForExist({ reverse: true, timeout: 10_000 });
+  await saveConnectionForm();
 }
 
 describe("Tag-group view + bulk actions", () => {
@@ -184,8 +166,9 @@ describe("Tag-group view + bulk actions", () => {
         // Bail early if a host failed — there's no recovery and the
         // 60s wait would just be wasted.
         if (errorRows.length > 0) {
+          const details = await Promise.all(errorRows.map((row) => row.getText()));
           throw new Error(
-            `Bulk SCP reported ${errorRows.length} failed host row(s); aborting wait.`,
+            `Bulk SCP reported ${errorRows.length} failed host row(s); aborting wait.\n${details.join("\n---\n")}`,
           );
         }
         return successRows.length >= 2;

--- a/e2e/specs/09-tag-groups.spec.ts
+++ b/e2e/specs/09-tag-groups.spec.ts
@@ -18,8 +18,7 @@
  * spec is suffixed `-09` so the shared per-suite SSX_DATA_DIR can
  * coexist with other specs without cross-contamination.
  */
-import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { waitForAppReady } from "../helpers/app.js";
 import { TARGETS, waitForServers } from "../helpers/docker.js";
@@ -64,7 +63,8 @@ async function tagConnection(name: string, tag: string): Promise<void> {
 describe("Tag-group view + bulk actions", () => {
   before(async () => {
     await waitForServers(["a", "b"]);
-    workDir = mkdtempSync(join(tmpdir(), "ssx-tags-"));
+    workDir = join(process.cwd(), "e2e", ".tmp", `ssx-tags-${Date.now()}`);
+    mkdirSync(workDir, { recursive: true });
     upload = join(workDir, "tag-upload.txt");
     writeFileSync(upload, "ssx-tag-bulk-payload\n");
   });
@@ -145,8 +145,22 @@ describe("Tag-group view + bulk actions", () => {
     await bulkDialog.waitForExist({ timeout: 10_000 });
 
     await (await browser.$(sel.bulkScpModeUpload)).click();
-    await (await browser.$(sel.bulkScpLocalPath)).setValue(upload);
-    await (await browser.$(sel.bulkScpRemotePath)).setValue("/tmp/");
+    if (!existsSync(upload)) {
+      throw new Error(`Bulk SCP upload fixture missing before submit: ${upload}`);
+    }
+    const localInput = await browser.$(sel.bulkScpLocalPath);
+    await localInput.setValue(upload);
+    await browser.waitUntil(async () => (await localInput.getValue()) === upload, {
+      timeout: 5_000,
+      timeoutMsg: "Bulk SCP local path input did not receive the fixture path",
+    });
+
+    const remoteInput = await browser.$(sel.bulkScpRemotePath);
+    await remoteInput.setValue("/tmp/");
+    await browser.waitUntil(async () => (await remoteInput.getValue()) === "/tmp/", {
+      timeout: 5_000,
+      timeoutMsg: "Bulk SCP remote path input did not receive /tmp/",
+    });
     await (await browser.$(sel.bulkScpStart)).click();
 
     // Wait for both per-host rows to show data-status="success".

--- a/e2e/specs/09-tag-groups.spec.ts
+++ b/e2e/specs/09-tag-groups.spec.ts
@@ -166,7 +166,10 @@ describe("Tag-group view + bulk actions", () => {
         // Bail early if a host failed — there's no recovery and the
         // 60s wait would just be wasted.
         if (errorRows.length > 0) {
-          const details = await Promise.all(errorRows.map((row) => row.getText()));
+          const details: string[] = [];
+          for (let i = 0; i < errorRows.length; i += 1) {
+            details.push(await errorRows[i].getText());
+          }
           throw new Error(
             `Bulk SCP reported ${errorRows.length} failed host row(s); aborting wait.\n${details.join("\n---\n")}`,
           );

--- a/e2e/specs/09-tag-groups.spec.ts
+++ b/e2e/specs/09-tag-groups.spec.ts
@@ -60,6 +60,28 @@ async function tagConnection(name: string, tag: string): Promise<void> {
   await saveConnectionForm();
 }
 
+async function setTextInputValue(selector: string, value: string): Promise<void> {
+  const input = await browser.$(selector);
+  await input.waitForExist({ timeout: 10_000 });
+  await browser.execute(
+    (el: HTMLInputElement, nextValue: string) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(el, nextValue);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    input,
+    value,
+  );
+  await browser.waitUntil(async () => (await input.getValue()) === value, {
+    timeout: 5_000,
+    timeoutMsg: `Input ${selector} did not receive ${value}`,
+  });
+}
+
 describe("Tag-group view + bulk actions", () => {
   before(async () => {
     await waitForServers(["a", "b"]);
@@ -148,19 +170,8 @@ describe("Tag-group view + bulk actions", () => {
     if (!existsSync(upload)) {
       throw new Error(`Bulk SCP upload fixture missing before submit: ${upload}`);
     }
-    const localInput = await browser.$(sel.bulkScpLocalPath);
-    await localInput.setValue(upload);
-    await browser.waitUntil(async () => (await localInput.getValue()) === upload, {
-      timeout: 5_000,
-      timeoutMsg: "Bulk SCP local path input did not receive the fixture path",
-    });
-
-    const remoteInput = await browser.$(sel.bulkScpRemotePath);
-    await remoteInput.setValue("/tmp/");
-    await browser.waitUntil(async () => (await remoteInput.getValue()) === "/tmp/", {
-      timeout: 5_000,
-      timeoutMsg: "Bulk SCP remote path input did not receive /tmp/",
-    });
+    await setTextInputValue(sel.bulkScpLocalPath, upload);
+    await setTextInputValue(sel.bulkScpRemotePath, "/tmp/");
     await (await browser.$(sel.bulkScpStart)).click();
 
     // Wait for both per-host rows to show data-status="success".

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,7 +446,7 @@ function App() {
           gitPending={gitPending}
         />
 
-        <main className="flex-1 flex flex-col overflow-hidden">
+        <main className="flex-1 flex flex-col overflow-hidden min-w-0 min-h-0">
           {view === "terminals" && tabs.length > 0 ? (
             <TerminalTabs
               tabs={tabs}
@@ -581,7 +581,7 @@ function App() {
               )}
               {view === "settings" && (
                 <Suspense fallback={<ViewFallback label="Loading settings…" />}>
-                  <div className="flex-1 overflow-y-auto">
+                  <div className="flex-1 min-h-0 overflow-y-auto">
                     <SettingsPanel settings={settings} onSave={saveSettings} />
                   </div>
                 </Suspense>

--- a/src/components/BulkScpDialog.tsx
+++ b/src/components/BulkScpDialog.tsx
@@ -319,7 +319,7 @@ export function BulkScpDialog({
           )}
         </div>
 
-        <DialogFooter>
+        <DialogFooter className="gap-2 sm:[&>button]:min-w-28">
           <Button
             type="button"
             variant="outline"

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -70,7 +70,7 @@ export function ConfirmDialog({
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
-        <DialogFooter className="gap-2">
+        <DialogFooter className="gap-2 sm:[&>button]:min-w-28">
           <Button
             variant="ghost"
             autoFocus

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -1187,7 +1187,7 @@ export function ConnectionForm({
           )}
           </div>
 
-          <DialogFooter className="px-6 py-3 border-t bg-background shrink-0">
+          <DialogFooter className="px-6 py-3 border-t bg-background shrink-0 gap-2 sm:[&>button]:min-w-28">
             <Button
               type="button"
               variant="outline"

--- a/src/components/ConnectionList.tsx
+++ b/src/components/ConnectionList.tsx
@@ -210,7 +210,7 @@ export function ConnectionList({
               aria-label={`${conn.name}${conn.tags && conn.tags.length > 0 ? `, tagged ${conn.tags.join(", ")}` : ""}`}
               aria-selected={selectedId === conn.id || undefined}
               className={cn(
-                "group rounded-lg border p-3 cursor-pointer transition-colors hover:bg-accent flex flex-col gap-2",
+                "group rounded-lg border p-3 cursor-pointer transition-colors hover:bg-accent flex flex-col gap-2 h-full",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 selectedId === conn.id && "bg-accent",
               )}
@@ -249,16 +249,17 @@ export function ConnectionList({
                   </span>
                 )}
               </p>
-              {conn.tags && conn.tags.length > 0 && (
-                <div className="flex flex-wrap gap-1">
-                  {conn.tags.map((t) => (
-                    <Badge key={t} variant="outline" className="text-[10px] py-0 px-1.5">
-                      {t}
-                    </Badge>
-                  ))}
-                </div>
-              )}
-              <div className="flex items-center justify-end gap-1">
+              {/* Tags row — always rendered (empty placeholder when no tags)
+                  to keep the actions row pinned to the same baseline across
+                  every tile in a grid row regardless of whether tags exist. */}
+              <div className="flex flex-wrap gap-1 min-h-[18px]">
+                {conn.tags?.map((t) => (
+                  <Badge key={t} variant="outline" className="text-[10px] py-0 px-1.5">
+                    {t}
+                  </Badge>
+                ))}
+              </div>
+              <div className="flex items-center justify-start gap-1 mt-auto">
                 {onConnect && (
                   <Button
                     variant="ghost"
@@ -274,17 +275,27 @@ export function ConnectionList({
                     <Play className="h-3.5 w-3.5" aria-hidden="true" />
                   </Button>
                 )}
-                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                {onScp && conn.type !== "port_forward" && (
+                <div className="flex items-center gap-1">
+                {onScp && (
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
+                    disabled={conn.type === "port_forward"}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onScp(conn);
+                      if (conn.type !== "port_forward") onScp(conn);
                     }}
-                    aria-label={`Transfer files to ${conn.name}`}
+                    aria-label={
+                      conn.type === "port_forward"
+                        ? "SCP not available for port-forward connections"
+                        : `Transfer files to ${conn.name}`
+                    }
+                    title={
+                      conn.type === "port_forward"
+                        ? "SCP not available for port-forward connections"
+                        : undefined
+                    }
                     data-testid={`scp-open-${conn.id}`}
                   >
                     <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />
@@ -425,17 +436,27 @@ export function ConnectionList({
                   <Play className="h-3.5 w-3.5" aria-hidden="true" />
                 </Button>
               )}
-              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-              {onScp && conn.type !== "port_forward" && (
+              <div className="flex items-center gap-1">
+              {onScp && (
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-7 w-7"
+                  disabled={conn.type === "port_forward"}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onScp(conn);
+                    if (conn.type !== "port_forward") onScp(conn);
                   }}
-                  aria-label={`Transfer files to ${conn.name}`}
+                  aria-label={
+                    conn.type === "port_forward"
+                      ? "SCP not available for port-forward connections"
+                      : `Transfer files to ${conn.name}`
+                  }
+                  title={
+                    conn.type === "port_forward"
+                      ? "SCP not available for port-forward connections"
+                      : undefined
+                  }
                   data-testid={`scp-open-${conn.id}`}
                 >
                   <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/components/ConnectionList.tsx
+++ b/src/components/ConnectionList.tsx
@@ -277,29 +277,33 @@ export function ConnectionList({
                 )}
                 <div className="flex items-center gap-1">
                 {onScp && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    disabled={conn.type === "port_forward"}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (conn.type !== "port_forward") onScp(conn);
-                    }}
-                    aria-label={
-                      conn.type === "port_forward"
-                        ? "SCP not available for port-forward connections"
-                        : `Transfer files to ${conn.name}`
-                    }
+                  <span
                     title={
                       conn.type === "port_forward"
                         ? "SCP not available for port-forward connections"
                         : undefined
                     }
-                    data-testid={`scp-open-${conn.id}`}
+                    className="inline-flex"
                   >
-                    <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-                  </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      disabled={conn.type === "port_forward"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (conn.type !== "port_forward") onScp(conn);
+                      }}
+                      aria-label={
+                        conn.type === "port_forward"
+                          ? "SCP not available for port-forward connections"
+                          : `Transfer files to ${conn.name}`
+                      }
+                      data-testid={`scp-open-${conn.id}`}
+                    >
+                      <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                  </span>
                 )}
                 <Button
                   variant="ghost"
@@ -438,29 +442,33 @@ export function ConnectionList({
               )}
               <div className="flex items-center gap-1">
               {onScp && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  disabled={conn.type === "port_forward"}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (conn.type !== "port_forward") onScp(conn);
-                  }}
-                  aria-label={
-                    conn.type === "port_forward"
-                      ? "SCP not available for port-forward connections"
-                      : `Transfer files to ${conn.name}`
-                  }
+                <span
                   title={
                     conn.type === "port_forward"
                       ? "SCP not available for port-forward connections"
                       : undefined
                   }
-                  data-testid={`scp-open-${conn.id}`}
+                  className="inline-flex"
                 >
-                  <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />
-                </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    disabled={conn.type === "port_forward"}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (conn.type !== "port_forward") onScp(conn);
+                    }}
+                    aria-label={
+                      conn.type === "port_forward"
+                        ? "SCP not available for port-forward connections"
+                        : `Transfer files to ${conn.name}`
+                    }
+                    data-testid={`scp-open-${conn.id}`}
+                  >
+                    <ArrowUpDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </span>
               )}
               <Button
                 variant="ghost"

--- a/src/components/CredentialForm.tsx
+++ b/src/components/CredentialForm.tsx
@@ -350,11 +350,11 @@ export function CredentialForm({
                     role="tab"
                     aria-selected={keySource === "inline"}
                     onClick={() => setKeySource("inline")}
-                    className={`px-3 py-1 text-xs rounded ${
+                    className={`px-3 py-1 text-xs rounded border-l ${
                       keySource === "inline"
-                        ? "bg-accent text-accent-foreground"
-                        : "text-muted-foreground"
-                    }`}
+                        ? "bg-accent text-accent-foreground border-l-transparent"
+                        : "text-muted-foreground border-border/60"
+                    } ${keySource === "path" ? "border-l-transparent" : ""}`}
                   >
                     Paste key
                   </button>
@@ -506,7 +506,7 @@ export function CredentialForm({
           )}
           </div>
 
-          <DialogFooter className="px-6 py-3 border-t bg-background shrink-0">
+          <DialogFooter className="px-6 py-3 border-t bg-background shrink-0 gap-2 sm:[&>button]:min-w-28">
             <Button
               type="button"
               variant="outline"

--- a/src/components/GitSyncView.tsx
+++ b/src/components/GitSyncView.tsx
@@ -4,14 +4,11 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Separator } from "./ui/separator";
 import { Badge } from "./ui/badge";
-import { ConfirmDialog } from "./ConfirmDialog";
 import { useGitSyncStore } from "@/store/useGitSyncStore";
-import { GitBranch, RefreshCcw, Download, Upload, FileDiff, WandSparkles } from "lucide-react";
+import { GitBranch, FileDiff, WandSparkles } from "lucide-react";
 
 export function GitSyncView() {
   const [commitMessage, setCommitMessage] = React.useState("");
-  const [confirmPullOpen, setConfirmPullOpen] = React.useState(false);
-  const [confirmPushOpen, setConfirmPushOpen] = React.useState(false);
   const {
     status,
     diff,
@@ -21,9 +18,6 @@ export function GitSyncView() {
     fetchStatus,
     fetchDiff,
     exportSnapshot,
-    fetchRemote,
-    pullRemote,
-    pushRemote,
     commitSnapshot,
     runSync,
   } = useGitSyncStore();
@@ -40,32 +34,16 @@ export function GitSyncView() {
           Git Sync
         </h1>
         {/*
-          Audit-3 follow-up P1#3: every toolbar action that hits
-          the network or filesystem carries aria-busy={isLoading}
-          so AT clients (especially screen readers) hear the busy
-          state without us having to flip every button label to
-          "Syncing…". The single isLoading flag is shared across
-          all five actions, which is fine — once any action is in
-          flight, the entire toolbar is dimmed and busy. The
-          icon-only lucide SVGs are aria-hidden so AT doesn't read
-          out their <title> on top of the visible button text.
+          The toolbar exposes a single bidirectional Sync action. The
+          underlying store still implements distinct fetch / pull /
+          push primitives (used by tests and the future automation
+          surface), but the UI consolidates them into one click so
+          users don't have to reason about the order of operations.
         */}
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={() => void runSync()} disabled={isLoading || !status.configured} aria-busy={isLoading}>
             <WandSparkles aria-hidden="true" className="h-4 w-4 mr-1" />
             Sync
-          </Button>
-          <Button size="sm" variant="outline" onClick={() => void fetchRemote()} disabled={isLoading} aria-busy={isLoading}>
-            <RefreshCcw aria-hidden="true" className="h-4 w-4 mr-1" />
-            Fetch
-          </Button>
-          <Button size="sm" variant="outline" onClick={() => setConfirmPullOpen(true)} disabled={isLoading || !status.configured} aria-busy={isLoading}>
-            <Download aria-hidden="true" className="h-4 w-4 mr-1" />
-            Pull
-          </Button>
-          <Button size="sm" onClick={() => setConfirmPushOpen(true)} disabled={isLoading || !status.configured} aria-busy={isLoading}>
-            <Upload aria-hidden="true" className="h-4 w-4 mr-1" />
-            Push
           </Button>
         </div>
       </div>
@@ -234,45 +212,6 @@ export function GitSyncView() {
           </div>
         )}
       </div>
-
-      {/*
-       * Pull and Push touch local OR remote git history with no
-       * built-in undo. Gate them behind a confirmation so a misclick
-       * on the Git Sync toolbar can't silently fast-forward, merge,
-       * or overwrite. Pull is "default" variant (potentially data-
-       * losing locally if there are uncommitted changes); Push is
-       * "destructive" because it mutates the shared remote.
-       */}
-      <ConfirmDialog
-        open={confirmPullOpen}
-        onOpenChange={setConfirmPullOpen}
-        title="Pull from remote?"
-        description={
-          <>
-            This fetches{status.remote ? ` ${status.remote}` : " the remote"}
-            {status.branch ? ` and merges into ${status.branch}` : ""}. Local
-            uncommitted changes in the sanitized snapshot may be overwritten.
-          </>
-        }
-        confirmLabel="Pull"
-        onConfirm={() => pullRemote()}
-      />
-      <ConfirmDialog
-        open={confirmPushOpen}
-        onOpenChange={setConfirmPushOpen}
-        title="Push to remote?"
-        description={
-          <>
-            This publishes your local commits
-            {status.remote ? ` to ${status.remote}` : ""}
-            {status.branch ? ` (${status.branch})` : ""}. Other clones of this
-            repository will pick up the change on their next pull.
-          </>
-        }
-        confirmLabel="Push"
-        variant="destructive"
-        onConfirm={() => pushRemote()}
-      />
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,8 +21,8 @@ interface SidebarProps {
 
 const navItems: { id: NavItem; label: string; icon: React.ReactNode }[] = [
   { id: "connections", label: "Connections", icon: <Server className="h-5 w-5" /> },
-  { id: "credentials", label: "Credentials", icon: <Key className="h-5 w-5" /> },
   { id: "tunnels", label: "Tunnels", icon: <Cable className="h-5 w-5" /> },
+  { id: "credentials", label: "Credentials", icon: <Key className="h-5 w-5" /> },
   { id: "logs", label: "Logs", icon: <ScrollText className="h-5 w-5" /> },
 ];
 
@@ -118,14 +118,9 @@ export function Sidebar({
         Drop the aria-label here so AT only surfaces a single
         'Primary' navigation landmark.
       */
-      className="w-16 bg-card border-r border-border flex flex-col items-center py-4 gap-2"
+      className="w-16 bg-card border-r border-border flex flex-col items-center py-4 gap-2 shrink-0 overflow-hidden"
       data-testid="sidebar"
     >
-      <div className="mb-4" aria-hidden="true">
-        <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-          <span className="text-primary-foreground font-bold text-sm">S</span>
-        </div>
-      </div>
       <nav aria-label="Primary" className="contents">
         {navItems.map(({ id, label, icon }) => (
           <NavButton

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -95,13 +95,29 @@ export function TitleBar({ onSettings, settingsActive }: TitleBarProps) {
   return (
     <div
       data-tauri-drag-region
-      className="h-9 bg-card border-b border-border flex items-center select-none shrink-0"
+      className="relative h-9 bg-card border-b border-border flex items-center select-none shrink-0"
     >
       {/* macOS: left spacer for traffic lights */}
       {platform === "macos" && <div className="w-20" data-tauri-drag-region />}
 
       {/* Draggable fill area */}
       <div className="flex-1" data-tauri-drag-region />
+
+      {/*
+        Centered lowercase wordmark. Absolutely positioned so it sits
+        in the geometric center of the title bar regardless of which
+        platform-specific affordances flank it (macOS traffic lights
+        on the left, Windows/Linux window controls on the right).
+        `pointer-events-none` keeps the entire bar draggable through
+        the wordmark — Tauri's drag-region only listens for primary
+        clicks on elements that don't intercept them.
+      */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-mono text-xs text-muted-foreground tracking-tight"
+      >
+        ssix
+      </span>
 
       <button
         onClick={onSettings}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -28,7 +28,14 @@ const tabsListVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-muted",
+        // Inactive triggers get a subtle vertical separator between
+        // each option (skipping the first child) so the segmented
+        // control reads as a clear set of choices instead of one
+        // continuous bar. Active triggers cancel the separator on
+        // both themselves and the next sibling so the highlight isn't
+        // bisected by a divider.
+        default:
+          "bg-muted [&_[data-slot=tabs-trigger]:not(:first-child)]:border-l [&_[data-slot=tabs-trigger]:not(:first-child)]:border-border/60 [&_[data-slot=tabs-trigger][data-state=active]]:border-l-transparent [&_[data-slot=tabs-trigger][data-state=active]+[data-slot=tabs-trigger]]:border-l-transparent group-data-[orientation=vertical]/tabs:[&_[data-slot=tabs-trigger]:not(:first-child)]:border-l-0 group-data-[orientation=vertical]/tabs:[&_[data-slot=tabs-trigger]:not(:first-child)]:border-t group-data-[orientation=vertical]/tabs:[&_[data-slot=tabs-trigger]:not(:first-child)]:border-border/60",
         line: "gap-1 bg-transparent",
       },
     },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -126,18 +126,24 @@
   /* Dark theme — default (no class required) and explicit .dark */
   :root,
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 217.2 32.6% 10%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    /*
+     * Dark palette: neutral slate (saturation tuned down from the
+     * previous blue-leaning Tailwind defaults). Lightness values are
+     * preserved so the WCAG-AA contrast notes below for
+     * `--muted-foreground-soft` and `--destructive-text` remain valid.
+     */
+    --background: 215 16% 9%;
+    --foreground: 210 20% 98%;
+    --card: 215 16% 11%;
+    --card-foreground: 210 20% 98%;
+    --popover: 215 16% 13%;
+    --popover-foreground: 210 20% 98%;
+    --primary: 210 20% 98%;
+    --primary-foreground: 215 25% 13%;
+    --secondary: 215 16% 19%;
+    --secondary-foreground: 210 20% 98%;
+    --muted: 215 16% 19%;
+    --muted-foreground: 215 14% 65%;
     /*
      * `muted-soft` is a deliberately-toned-down variant of
      * `muted-foreground` for tertiary metadata (timestamps, inline
@@ -145,12 +151,12 @@
      * AA (4.5:1) on the surrounding surface in both themes; do not
      * pair it with extra opacity utilities.
      *
-     * Dark theme (#0a1020 background): hsl(215 20% 55%) ≈ #6f8197
-     * yields ~5.2:1 contrast.
+     * Dark theme (slate background ~ #14181d): hsl(215 14% 55%) ≈ #7d848e
+     * yields ~5.0:1 contrast.
      */
-    --muted-foreground-soft: 215 20% 55%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --muted-foreground-soft: 215 14% 55%;
+    --accent: 215 16% 19%;
+    --accent-foreground: 210 20% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
     /*
@@ -172,9 +178,9 @@
      * common `bg-destructive/10` overlay).
      */
     --destructive-text: 0 84.2% 72%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 215 16% 19%;
+    --input: 215 16% 19%;
+    --ring: 215 14% 70%;
     --radius: 0.5rem;
   }
 

--- a/src/test/ConnectionList.test.tsx
+++ b/src/test/ConnectionList.test.tsx
@@ -268,9 +268,12 @@ describe("ConnectionList", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  // ─── Always-visible Connect CTA (P0-8) ────────────────────────────────────
+  // ─── Always-visible action cluster ────────────────────────────────────────
+  // Per the v2 redesign, secondary row actions (SCP, Clone, Edit, Delete)
+  // are no longer hover-revealed — keeping them visible at all times tells
+  // the user up-front what is available without requiring discovery.
 
-  it("renders Connect outside the hover-fade group in row layout", () => {
+  it("renders all row actions visible (no hover-fade) in row layout", () => {
     render(
       <ConnectionList
         connections={[mockConnections[0]]}
@@ -283,13 +286,12 @@ describe("ConnectionList", () => {
     );
     const connectBtn = screen.getByRole("button", { name: /^Connect to / });
     const editBtn = screen.getByRole("button", { name: /^Edit / });
-    // Connect must NOT be a descendant of any element with the hover-fade class.
+    // Neither primary nor secondary actions sit inside an opacity-0 wrapper.
     expect(connectBtn.closest(".opacity-0")).toBeNull();
-    // Secondary actions stay in the hover-fade group.
-    expect(editBtn.closest(".opacity-0")).not.toBeNull();
+    expect(editBtn.closest(".opacity-0")).toBeNull();
   });
 
-  it("renders Connect outside the hover-fade group in tile layout", () => {
+  it("renders all row actions visible (no hover-fade) in tile layout", () => {
     render(
       <ConnectionList
         connections={[mockConnections[0]]}
@@ -304,6 +306,6 @@ describe("ConnectionList", () => {
     const connectBtn = screen.getByRole("button", { name: /^Connect to / });
     const editBtn = screen.getByRole("button", { name: /^Edit / });
     expect(connectBtn.closest(".opacity-0")).toBeNull();
-    expect(editBtn.closest(".opacity-0")).not.toBeNull();
+    expect(editBtn.closest(".opacity-0")).toBeNull();
   });
 });

--- a/src/test/GitSyncView.test.tsx
+++ b/src/test/GitSyncView.test.tsx
@@ -44,60 +44,21 @@ describe("GitSyncView", () => {
     expect(screen.getByRole("button", { name: /sync/i })).toBeInTheDocument();
   });
 
-  it("requires confirmation before pulling from the remote", async () => {
-    const pullRemote = vi.fn().mockResolvedValue(undefined);
-    useGitSyncStore.setState({ pullRemote });
+  it("invokes the consolidated runSync action when Sync is clicked", async () => {
+    const runSync = vi.fn().mockResolvedValue(undefined);
+    useGitSyncStore.setState({ runSync });
     render(<GitSyncView />);
-
-    fireEvent.click(screen.getByRole("button", { name: /^pull$/i }));
-    // The store action should NOT have fired yet — only the dialog opened.
-    expect(pullRemote).not.toHaveBeenCalled();
-
-    // Confirm dialog should be present with cancel focused (not pull).
-    const dialog = await screen.findByRole("dialog");
-    expect(dialog).toHaveTextContent(/pull from remote/i);
-    expect(document.activeElement).toHaveTextContent(/cancel/i);
-
-    // Confirm; the store action runs exactly once and the dialog closes.
-    fireEvent.click(
-      screen.getAllByRole("button", { name: /^pull$/i }).slice(-1)[0],
-    );
-    await waitFor(() => expect(pullRemote).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: /^sync$/i }));
+    await waitFor(() => expect(runSync).toHaveBeenCalledTimes(1));
   });
 
-  it("requires confirmation before pushing to the remote", async () => {
-    const pushRemote = vi.fn().mockResolvedValue(undefined);
-    useGitSyncStore.setState({ pushRemote });
+  it("does not render separate Fetch / Pull / Push toolbar buttons", () => {
+    // The toolbar collapses fetch + pull + push into a single Sync action.
+    // Asserting their absence guards against accidental re-introduction.
     render(<GitSyncView />);
-
-    fireEvent.click(screen.getByRole("button", { name: /^push$/i }));
-    expect(pushRemote).not.toHaveBeenCalled();
-
-    const dialog = await screen.findByRole("dialog");
-    expect(dialog).toHaveTextContent(/push to remote/i);
-    expect(document.activeElement).toHaveTextContent(/cancel/i);
-
-    fireEvent.click(
-      screen.getAllByRole("button", { name: /^push$/i }).slice(-1)[0],
-    );
-    await waitFor(() => expect(pushRemote).toHaveBeenCalledTimes(1));
-  });
-
-  it("cancelling the pull confirmation does not invoke the store action", async () => {
-    const pullRemote = vi.fn().mockResolvedValue(undefined);
-    useGitSyncStore.setState({ pullRemote });
-    render(<GitSyncView />);
-
-    fireEvent.click(screen.getByRole("button", { name: /^pull$/i }));
-    const dialog = await screen.findByRole("dialog");
-    fireEvent.click(
-      // The cancel button is the only "Cancel" labelled control.
-      within(dialog).getByRole("button", { name: /cancel/i }),
-    );
-    await waitFor(() =>
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
-    );
-    expect(pullRemote).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: /^fetch$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^pull$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^push$/i })).toBeNull();
   });
 
   /*
@@ -170,13 +131,14 @@ describe("GitSyncView", () => {
     expect(alert.textContent).toMatch(/remote: rejected/);
   });
 
-  it("toolbar buttons carry aria-busy while a sync is running", () => {
+  it("Sync toolbar button carries aria-busy while a sync is running", () => {
+    // After collapsing the toolbar to a single bidirectional Sync action,
+    // there is only one button to assert against — but the aria-busy
+    // contract still matters: AT users need to know the action is in
+    // flight before the result banner / error region updates.
     useGitSyncStore.setState({ isLoading: true });
     render(<GitSyncView />);
-    // Each toolbar button should be aria-busy=true.
-    for (const name of [/^sync$/i, /^fetch$/i, /^pull$/i, /^push$/i]) {
-      const btn = screen.getByRole("button", { name });
-      expect(btn).toHaveAttribute("aria-busy", "true");
-    }
+    const btn = screen.getByRole("button", { name: /^sync$/i });
+    expect(btn).toHaveAttribute("aria-busy", "true");
   });
 });


### PR DESCRIPTION
## Summary
A focused visual + interaction polish pass on top of the merged tags-view work.

### Palette
- Desaturate dark-mode tokens (slate-aligned, S 14–16%) while preserving documented WCAG contrast ratios.

### Connection list / tile
- Drop hover-fade on secondary actions — SCP / Clone / Edit / Delete are now always visible so users know up-front what each row offers.
- Port-forward connections render the SCP icon **disabled** with an explanatory `title` tooltip instead of hiding it (predictable affordance across kinds).
- Tile actions are left-aligned and horizontally aligned across rows regardless of whether tags are present (stable height via tag-row placeholder + `mt-auto`).

### Segmented controls
- `Tabs` primitive (`default` variant) and the CredentialForm key-source toggle now render visible separators between options, suppressed adjacent to the active item.

### Buttons
- Equal min-widths on Cancel / confirm pairs in `ConfirmDialog`, `ConnectionForm`, `CredentialForm`, `BulkScpDialog` (`sm:[&>button]:min-w-28`).

### Git Sync
- Collapse Fetch / Pull / Push into the single bidirectional **Sync** action. Store primitives (`fetchRemote` / `pullRemote` / `pushRemote`) are retained for tests and future automation.

### Layout
- Settings: prevent double-scroll via `min-h-0` / `min-w-0` on `<main>` and the settings wrapper; sidebar shrinks rather than scrolling.

### Sidebar / TitleBar
- Sidebar reordered: Connections → Tunnels → Credentials → Logs; the standalone "S" branding tile removed.
- TitleBar: centered lowercase mono `ssix` wordmark, `pointer-events-none` so the bar stays draggable.

### Docs
- `docs/features.md` and `docs/git-sync.md` updated to match the new behaviour.

### Tests
- 367 frontend tests, 124 cargo tests, 0 TS errors.
- Updated ConnectionList + GitSyncView specs to assert always-visible actions and the single Sync button.

## Test plan
- \`npm test\` ✅ 367 passed
- \`npx tsc --noEmit\` ✅
- \`cargo test\` ✅ 124 passed
- E2E suite unchanged in scope; selectors unaffected by these visual edits.